### PR TITLE
Revamp settings layout with sectioned cards

### DIFF
--- a/apps/lib/features/settings/presentation/settings_screen.dart
+++ b/apps/lib/features/settings/presentation/settings_screen.dart
@@ -25,214 +25,273 @@ class SettingsScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: Text(l10n.tabSettings)),
       body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 24, 16, 24),
         children: [
-          ListTile(
-            leading: const Icon(Icons.info_outline),
-            title: const Text('About'),
-            onTap: () => context.go('/about'),
+          _SettingsSection(
+            title: l10n.settingsGeneralSection,
+            subtitle: l10n.settingsGeneralSectionSubtitle,
+            children: [
+              _SettingsTile(
+                leading: const Icon(Icons.info_outline),
+                title: const Text('About'),
+                onTap: () => context.go('/about'),
+              ),
+              BlocBuilder<SyncBloc, SyncState>(
+                builder: (context, state) {
+                  final text = state.isSyncing
+                      ? l10n.settingsSyncing
+                      : (state.error != null
+                          ? l10n.settingsSyncError(state.error!)
+                          : l10n.settingsSyncIdle);
+                  return _SettingsTile(
+                    leading: const Icon(Icons.sync),
+                    title: Text(text),
+                    trailing: FilledButton.icon(
+                      icon: const Icon(Icons.cloud_upload_outlined),
+                      onPressed: state.isSyncing
+                          ? null
+                          : () => context.read<SyncBloc>().add(const SyncTriggered()),
+                      label: Text(l10n.settingsSyncNow),
+                    ),
+                  );
+                },
+              ),
+              BlocBuilder<SyncBloc, SyncState>(
+                buildWhen: (previous, current) => previous.lastSynced != current.lastSynced,
+                builder: (context, state) {
+                  if (state.lastSynced == null) return const SizedBox.shrink();
+                  return _SettingsTile(
+                    leading: const Icon(Icons.task_alt, color: Colors.green),
+                    title: Text(
+                      l10n.lastSyncAt(
+                        DateFormat.Hm().format(state.lastSynced!.toLocal()),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ],
           ),
-          BlocBuilder<SyncBloc, SyncState>(
-            builder: (context, state) {
-              final text = state.isSyncing
-                  ? l10n.settingsSyncing
-                  : (state.error != null
-                      ? l10n.settingsSyncError(state.error!)
-                      : l10n.settingsSyncIdle);
-              return ListTile(
-                title: Text(text),
-                trailing: FilledButton.icon(
-                  icon: const Icon(Icons.sync),
-                  onPressed: state.isSyncing
-                      ? null
-                      : () => context.read<SyncBloc>().add(const SyncTriggered()),
-                  label: Text(l10n.settingsSyncNow),
+          const SizedBox(height: 24),
+          _SettingsSection(
+            title: l10n.settingsPreferencesSection,
+            subtitle: l10n.settingsPreferencesSectionSubtitle,
+            children: [
+              SwitchListTile.adaptive(
+                contentPadding: const EdgeInsets.symmetric(horizontal: 20),
+                secondary: const Icon(Icons.dark_mode_outlined),
+                title: Text(l10n.settingsDarkMode),
+                value: isDark,
+                onChanged: (v) => context.read<ThemeCubit>().setDark(v),
+              ),
+              _SettingsTile(
+                leading: const Icon(Icons.language),
+                title: Text(l10n.settingsLanguage),
+                subtitle: Text(
+                  locale?.languageCode == 'km'
+                      ? l10n.settingsLanguageKm
+                      : l10n.settingsLanguageEn,
                 ),
-              );
-            },
-          ),
-          SwitchListTile(
-            title: Text(l10n.settingsDarkMode),
-            value: isDark,
-            onChanged: (v) => context.read<ThemeCubit>().setDark(v),
-          ),
-          SwitchListTile(
-            title: Text(l10n.settingsShowSyncBanner),
-            value: flags.showSyncBanner,
-            onChanged: (v) => context.read<FeatureFlagsCubit>().setShowSyncBanner(v),
-          ),
-          SwitchListTile(
-            title: Text(l10n.settingsEnableBatchSync),
-            value: flags.enableBatchSync,
-            onChanged: (v) => context.read<FeatureFlagsCubit>().setEnableBatchSync(v),
-          ),
-          SwitchListTile(
-            title: Text(AppLocalizations.of(context).settingsAllowOversell),
-            value: (KeyValueService.get<bool>('allow_oversell') ?? false),
-            onChanged: (v) async {
-              await KeyValueService.set<bool>('allow_oversell', v);
-              if (context.mounted) (context as Element).markNeedsBuild();
-            },
-          ),
-          ListTile(
-            title: Text(l10n.settingsBatchSize),
-            subtitle: Text(flags.batchSize.toString()),
-          ),
-          Slider(
-            value: flags.batchSize.toDouble(),
-            min: 5,
-            max: 50,
-            divisions: 9,
-            label: flags.batchSize.toString(),
-            onChanged: (v) => context.read<FeatureFlagsCubit>().setBatchSize(v.round()),
-          ),
-          // Low stock threshold
-          Builder(builder: (context) {
-            final threshold = KeyValueService.get<int>('low_stock_threshold') ?? 5;
-            return Column(
-              children: [
-                ListTile(
-                  title: Text(AppLocalizations.of(context).settingsLowStockThreshold),
-                  subtitle: Text(threshold.toString()),
-                ),
-                Slider(
-                  value: threshold.toDouble(),
-                  min: 0,
-                  max: 100,
-                  divisions: 20,
-                  label: threshold.toString(),
-                  onChanged: (v) async {
-                    await KeyValueService.set<int>('low_stock_threshold', v.round());
-                    if (context.mounted) (context as Element).markNeedsBuild();
-                  },
-                ),
-              ],
-            );
-          }),
-          const Divider(),
-          // Shop header/footer for receipts
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(AppLocalizations.of(context).receipt, style: Theme.of(context).textTheme.titleMedium),
-                const SizedBox(height: 8),
-                _SettingTextField(
-                  label: 'Shop name',
-                  storageKey: 'shop_name',
-                ),
-                const SizedBox(height: 8),
-                _SettingTextField(
-                  label: 'Address',
-                  storageKey: 'shop_address',
-                ),
-                const SizedBox(height: 8),
-                _SettingTextField(
-                  label: 'Phone',
-                  storageKey: 'shop_phone',
-                ),
-                const SizedBox(height: 8),
-                _SettingTextField(
-                  label: 'Footer note',
-                  storageKey: 'shop_footer',
-                ),
-              ],
-            ),
-          ),
-          const Divider(),
-          // Telegram bot settings (for direct send)
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: const [
-                _SettingTextField(label: 'Telegram bot token', storageKey: 'tg_bot_token'),
-                SizedBox(height: 8),
-                _SettingTextField(label: 'Telegram chat id', storageKey: 'tg_chat_id'),
-              ],
-            ),
-          ),
-          if (context.read<SyncBloc>().state.lastSynced != null)
-            ListTile(
-              leading: const Icon(Icons.check, color: Colors.green),
-              title: Text(
-                l10n.lastSyncAt(
-                  DateFormat.Hm().format(context.read<SyncBloc>().state.lastSynced!.toLocal()),
+                trailing: DropdownButtonHideUnderline(
+                  child: DropdownButton<Locale>(
+                    value: locale ?? const Locale('en'),
+                    items: const [
+                      DropdownMenuItem(value: Locale('en'), child: Text('English')),
+                      DropdownMenuItem(value: Locale('km'), child: Text('ខ្មែរ')),
+                    ],
+                    onChanged: (loc) => context.read<LocaleCubit>().setLocale(loc),
+                  ),
                 ),
               ),
-            ),
-          ListTile(
-            title: Text(l10n.settingsLanguage),
-            subtitle: Text(locale?.languageCode == 'km'
-                ? l10n.settingsLanguageKm
-                : l10n.settingsLanguageEn),
-            trailing: DropdownButton<Locale>(
-              value: locale ?? const Locale('en'),
-              items: const [
-                DropdownMenuItem(value: Locale('en'), child: Text('English')),
-                DropdownMenuItem(value: Locale('km'), child: Text('ខ្មែរ')),
-              ],
-              onChanged: (loc) => context.read<LocaleCubit>().setLocale(loc),
-            ),
+            ],
           ),
-          const Divider(),
-          // Static KHQR settings
-          Builder(builder: (context) {
-            final khqrPath = KeyValueService.get<String>('khqr_image_path');
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                ListTile(
-                  title: Text(l10n.settingsKhqrTitle),
-                  subtitle: Text(khqrPath == null ? l10n.settingsKhqrNotSet : khqrPath),
+          const SizedBox(height: 24),
+          _SettingsSection(
+            title: l10n.settingsSyncSection,
+            subtitle: l10n.settingsSyncSectionSubtitle,
+            children: [
+              SwitchListTile.adaptive(
+                contentPadding: const EdgeInsets.symmetric(horizontal: 20),
+                secondary: const Icon(Icons.campaign_outlined),
+                title: Text(l10n.settingsShowSyncBanner),
+                value: flags.showSyncBanner,
+                onChanged: (v) => context.read<FeatureFlagsCubit>().setShowSyncBanner(v),
+              ),
+              SwitchListTile.adaptive(
+                contentPadding: const EdgeInsets.symmetric(horizontal: 20),
+                secondary: const Icon(Icons.playlist_add_check_circle_outlined),
+                title: Text(l10n.settingsEnableBatchSync),
+                value: flags.enableBatchSync,
+                onChanged: (v) => context.read<FeatureFlagsCubit>().setEnableBatchSync(v),
+              ),
+              SwitchListTile.adaptive(
+                contentPadding: const EdgeInsets.symmetric(horizontal: 20),
+                secondary: const Icon(Icons.inventory_2_outlined),
+                title: Text(l10n.settingsAllowOversell),
+                value: (KeyValueService.get<bool>('allow_oversell') ?? false),
+                onChanged: (v) async {
+                  await KeyValueService.set<bool>('allow_oversell', v);
+                  if (context.mounted) (context as Element).markNeedsBuild();
+                },
+              ),
+              _SettingsTile(
+                leading: const Icon(Icons.tune),
+                title: Text(l10n.settingsBatchSize),
+                subtitle: Text(l10n.settingsBatchSizeHint(flags.batchSize)),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: Slider(
+                  value: flags.batchSize.toDouble(),
+                  min: 5,
+                  max: 50,
+                  divisions: 9,
+                  label: flags.batchSize.toString(),
+                  onChanged: (v) => context.read<FeatureFlagsCubit>().setBatchSize(v.round()),
                 ),
-                if (khqrPath != null)
-                  Padding(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: ClipRRect(
-                      borderRadius: BorderRadius.circular(8),
-                      child: Image.file(File(khqrPath), height: 160, fit: BoxFit.contain),
-                    ),
-                  ),
-                ButtonBar(
-                  alignment: MainAxisAlignment.start,
+              ),
+              Builder(builder: (context) {
+                final threshold = KeyValueService.get<int>('low_stock_threshold') ?? 5;
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    OutlinedButton.icon(
-                      icon: const Icon(Icons.upload),
-                      label: Text(l10n.settingsUploadKhqr),
-                      onPressed: () async {
-                        final picker = ImagePicker();
-                        final picked = await picker.pickImage(source: ImageSource.gallery);
-                        if (picked == null) return;
-                        final appDir = await getApplicationDocumentsDirectory();
-                        final dst = File('${appDir.path}/khqr.png');
-                        await File(picked.path).copy(dst.path);
-                        await KeyValueService.set<String>('khqr_image_path', dst.path);
-                        if (context.mounted) (context as Element).markNeedsBuild();
-                      },
+                    _SettingsTile(
+                      leading: const Icon(Icons.inventory_outlined),
+                      title: Text(l10n.settingsLowStockThreshold),
+                      subtitle: Text(
+                        l10n.settingsLowStockThresholdDescription(threshold),
+                      ),
                     ),
-                    if (khqrPath != null)
-                      TextButton.icon(
-                        icon: const Icon(Icons.delete),
-                        label: Text(l10n.settingsRemoveKhqr),
-                        onPressed: () async {
-                          await KeyValueService.remove('khqr_image_path');
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 20),
+                      child: Slider(
+                        value: threshold.toDouble(),
+                        min: 0,
+                        max: 100,
+                        divisions: 20,
+                        label: threshold.toString(),
+                        onChanged: (v) async {
+                          await KeyValueService.set<int>('low_stock_threshold', v.round());
                           if (context.mounted) (context as Element).markNeedsBuild();
                         },
                       ),
+                    ),
                   ],
+                );
+              }),
+            ],
+          ),
+          const SizedBox(height: 24),
+          _SettingsSection(
+            title: l10n.settingsReceiptSection,
+            subtitle: l10n.settingsReceiptSectionSubtitle,
+            children: const [
+              _SettingTextField(
+                label: 'Shop name',
+                storageKey: 'shop_name',
+              ),
+              _SettingsDivider(),
+              _SettingTextField(
+                label: 'Address',
+                storageKey: 'shop_address',
+              ),
+              _SettingsDivider(),
+              _SettingTextField(
+                label: 'Phone',
+                storageKey: 'shop_phone',
+              ),
+              _SettingsDivider(),
+              _SettingTextField(
+                label: 'Footer note',
+                storageKey: 'shop_footer',
+              ),
+            ],
+          ),
+          const SizedBox(height: 24),
+          _SettingsSection(
+            title: l10n.settingsPaymentSection,
+            subtitle: l10n.settingsPaymentSectionSubtitle,
+            children: [
+              Builder(builder: (context) {
+                final khqrPath = KeyValueService.get<String>('khqr_image_path');
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _SettingsTile(
+                      leading: const Icon(Icons.qr_code_2),
+                      title: Text(l10n.settingsKhqrTitle),
+                      subtitle: Text(khqrPath == null ? l10n.settingsKhqrNotSet : khqrPath),
+                    ),
+                    if (khqrPath != null)
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(20, 12, 20, 4),
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(12),
+                          child: Image.file(
+                            File(khqrPath),
+                            height: 160,
+                            fit: BoxFit.contain,
+                          ),
+                        ),
+                      ),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 12),
+                      child: Wrap(
+                        spacing: 12,
+                        runSpacing: 8,
+                        children: [
+                          OutlinedButton.icon(
+                            icon: const Icon(Icons.upload),
+                            label: Text(l10n.settingsUploadKhqr),
+                            onPressed: () async {
+                              final picker = ImagePicker();
+                              final picked = await picker.pickImage(source: ImageSource.gallery);
+                              if (picked == null) return;
+                              final appDir = await getApplicationDocumentsDirectory();
+                              final dst = File('${appDir.path}/khqr.png');
+                              await File(picked.path).copy(dst.path);
+                              await KeyValueService.set<String>('khqr_image_path', dst.path);
+                              if (context.mounted) (context as Element).markNeedsBuild();
+                            },
+                          ),
+                          if (khqrPath != null)
+                            TextButton.icon(
+                              icon: const Icon(Icons.delete_outline),
+                              label: Text(l10n.settingsRemoveKhqr),
+                              onPressed: () async {
+                                await KeyValueService.remove('khqr_image_path');
+                                if (context.mounted) (context as Element).markNeedsBuild();
+                              },
+                            ),
+                        ],
+                      ),
+                    ),
+                  ],
+                );
+              }),
+              const _SettingsDivider(),
+              const _SettingTextField(label: 'Telegram bot token', storageKey: 'tg_bot_token'),
+              const _SettingsDivider(),
+              const _SettingTextField(label: 'Telegram chat id', storageKey: 'tg_chat_id'),
+            ],
+          ),
+          const SizedBox(height: 24),
+          _SettingsSection(
+            title: l10n.settingsDangerZone,
+            subtitle: l10n.settingsDangerZoneSubtitle,
+            children: [
+              _SettingsTile(
+                leading: const Icon(Icons.logout, color: Colors.red),
+                title: Text(
+                  l10n.loginTitle,
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(color: Colors.redAccent),
                 ),
-                const Divider(),
-              ],
-            );
-          }),
-          ListTile(
-            title: Text(l10n.loginTitle),
-            leading: const Icon(Icons.logout),
-            onTap: () async {
-              context.read<AuthBloc>().add(const AuthSignedOut());
-              if (context.mounted) context.go('/login');
-            },
+                onTap: () async {
+                  context.read<AuthBloc>().add(const AuthSignedOut());
+                  if (context.mounted) context.go('/login');
+                },
+              ),
+            ],
           ),
         ],
       ),
@@ -266,10 +325,120 @@ class _SettingTextFieldState extends State<_SettingTextField> {
 
   @override
   Widget build(BuildContext context) {
-    return TextField(
-      controller: _ctrl,
-      decoration: InputDecoration(labelText: widget.label, border: const OutlineInputBorder(), isDense: true),
-      onChanged: (v) => KeyValueService.set<String>(widget.storageKey, v.trim()),
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+      child: TextField(
+        controller: _ctrl,
+        decoration: InputDecoration(
+          labelText: widget.label,
+          border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+          enabledBorder: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(12),
+            borderSide: BorderSide(color: theme.colorScheme.outline.withOpacity(0.4)),
+          ),
+          isDense: true,
+          filled: true,
+          fillColor: theme.colorScheme.surfaceVariant.withOpacity(theme.brightness == Brightness.dark ? 0.24 : 0.5),
+        ),
+        onChanged: (v) => KeyValueService.set<String>(widget.storageKey, v.trim()),
+      ),
     );
   }
+}
+
+class _SettingsSection extends StatelessWidget {
+  final String title;
+  final String? subtitle;
+  final List<Widget> children;
+  const _SettingsSection({required this.title, this.subtitle, required this.children});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final foregroundMuted = theme.colorScheme.onSurfaceVariant;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        if (subtitle != null) ...[
+          const SizedBox(height: 4),
+          Text(
+            subtitle!,
+            style: textTheme.bodySmall?.copyWith(color: foregroundMuted),
+          ),
+        ],
+        const SizedBox(height: 12),
+        Card(
+          clipBehavior: Clip.antiAlias,
+          elevation: 0,
+          margin: EdgeInsets.zero,
+          color: theme.colorScheme.surfaceVariant.withOpacity(theme.brightness == Brightness.dark ? 0.3 : 0.8),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+          child: Column(
+            children: [
+              for (final widget in children) ...[
+                if (widget is _SettingsDivider)
+                  const Divider(height: 1)
+                else
+                  widget,
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SettingsTile extends StatelessWidget {
+  final Widget? leading;
+  final Widget title;
+  final Widget? subtitle;
+  final Widget? trailing;
+  final VoidCallback? onTap;
+  const _SettingsTile({this.leading, required this.title, this.subtitle, this.trailing, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final foregroundMuted = theme.colorScheme.onSurfaceVariant;
+
+    return ListTile(
+      leading: leading == null
+          ? null
+          : IconTheme.merge(
+              data: IconThemeData(color: theme.colorScheme.primary),
+              child: leading!,
+            ),
+      minLeadingWidth: 32,
+      title: DefaultTextStyle.merge(
+        style: textTheme.titleMedium,
+        child: title,
+      ),
+      subtitle: subtitle == null
+          ? null
+          : DefaultTextStyle.merge(
+              style: textTheme.bodySmall?.copyWith(color: foregroundMuted),
+              child: subtitle!,
+            ),
+      trailing: trailing,
+      onTap: onTap,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+      horizontalTitleGap: 12,
+    );
+  }
+}
+
+class _SettingsDivider extends StatelessWidget {
+  const _SettingsDivider();
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
 }

--- a/apps/lib/l10n/app_en.arb
+++ b/apps/lib/l10n/app_en.arb
@@ -10,26 +10,27 @@
   "settingsLanguage": "Language",
   "settingsLanguageKm": "Khmer",
   "settingsLanguageEn": "English",
-  "settingsDarkMode": "Dark Mode"
-  ,
+  "settingsDarkMode": "Dark Mode",
+  "settingsGeneralSection": "Workspace",
+  "settingsGeneralSectionSubtitle": "Manage your profile and sync status.",
   "settingsSyncNow": "Sync now",
   "settingsSyncIdle": "Sync idle",
   "settingsSyncing": "Syncing...",
-  "settingsSyncError": "Sync error: {message}"
-  ,
+  "settingsSyncError": "Sync error: {message}",
   "settingsSyncDeleted": "Deleted",
   "undo": "UNDO",
   "noProducts": "No products",
   "noSales": "No sales",
   "noPayments": "No payments",
-  "lastSyncAt": "Last sync: {time}"
-  ,
-  "settingsShowSyncBanner": "Show sync banner"
-  ,
-  "settingsEnableBatchSync": "Enable batch sync"
-  ,
-  "settingsBatchSize": "Batch size"
-  ,
+  "lastSyncAt": "Last sync: {time}",
+  "settingsShowSyncBanner": "Show sync banner",
+  "settingsEnableBatchSync": "Enable batch sync",
+  "settingsBatchSize": "Batch size",
+  "settingsBatchSizeHint": "Process {size} invoices per batch",
+  "settingsPreferencesSection": "Preferences",
+  "settingsPreferencesSectionSubtitle": "Personalize how the app looks and feels.",
+  "settingsSyncSection": "Automation",
+  "settingsSyncSectionSubtitle": "Fine tune batch sync and inventory safeguards.",
   "aboutTitle": "About",
   "aboutDbVersion": "DB version",
   "aboutAppVersion": "App version",
@@ -72,6 +73,7 @@
   "txRefLabel": "Ref: {ref}"
   ,
   "settingsLowStockThreshold": "Low stock threshold",
+  "settingsLowStockThresholdDescription": "Alert when stock falls below {threshold}",
   "adjustStockTitle": "Adjust Stock",
   "stockLabel": "Stock",
   "decrease": "Decrease",
@@ -85,6 +87,12 @@
   "notEnoughStockFor": "Not enough stock for {name}. Available: {qty}"
   ,
   "settingsAllowOversell": "Allow oversell (warn only)",
+  "settingsReceiptSection": "Receipt branding",
+  "settingsReceiptSectionSubtitle": "Customize how your shop appears on printed receipts.",
+  "settingsPaymentSection": "Payment integrations",
+  "settingsPaymentSectionSubtitle": "Share KHQR codes and connect Telegram bots.",
+  "settingsDangerZone": "Danger zone",
+  "settingsDangerZoneSubtitle": "Sign out of this device.",
   "exceedsStock": "Exceeds stock"
   ,
   "receipt": "Receipt",

--- a/apps/lib/l10n/app_km.arb
+++ b/apps/lib/l10n/app_km.arb
@@ -11,6 +11,8 @@
   "settingsLanguageKm": "ខ្មែរ",
   "settingsLanguageEn": "អង់គ្លេស",
   "settingsDarkMode": "របៀបងងឹត",
+  "settingsGeneralSection": "កន្លែងធ្វើការ",
+  "settingsGeneralSectionSubtitle": "គ្រប់គ្រងព័ត៌មានសម្គាល់ និងស្ថានភាពសមកាលកម្ម។",
   "settingsSyncNow": "សមកាលកម្មឥឡូវនេះ",
   "settingsSyncIdle": "កំពុងសម្រាកសមកាលកម្ម",
   "settingsSyncing": "កំពុងសមកាលកម្ម...",
@@ -20,14 +22,15 @@
   "noProducts": "គ្មានផលិតផល",
   "noSales": "គ្មានការលក់",
   "noPayments": "គ្មានការទូទាត់",
-  "lastSyncAt": "សមកាលកម្មចុងក្រោយ: {time}"
-  ,
-  "settingsShowSyncBanner": "បង្ហាញបន្ទះសមកាលកម្ម"
-  ,
-  "settingsEnableBatchSync": "អនុញ្ញាតសមកាលកម្មជាក្បាល"
-  ,
-  "settingsBatchSize": "ទំហំក្បាល"
-  ,
+  "lastSyncAt": "សមកាលកម្មចុងក្រោយ: {time}",
+  "settingsShowSyncBanner": "បង្ហាញបន្ទះសមកាលកម្ម",
+  "settingsEnableBatchSync": "អនុញ្ញាតសមកាលកម្មជាក្បាល",
+  "settingsBatchSize": "ទំហំក្បាល",
+  "settingsBatchSizeHint": "ដំណើរការ {size} វិក័យប័ត្រក្នុងមួយក្បាល",
+  "settingsPreferencesSection": "ចំណូលចិត្ត",
+  "settingsPreferencesSectionSubtitle": "ប្ដូររបៀបដែលកម្មវិធីមើលទៅ និងមានអារម្មណ៍។",
+  "settingsSyncSection": "សមកាលកម្មស្វ័យប្រវត្តិ",
+  "settingsSyncSectionSubtitle": "លៃតម្រូវសមកាលកម្មជាក្បាល និងការពារស្តុក។",
   "aboutTitle": "អំពីកម្មវិធី",
   "aboutDbVersion": "កំណែនៃមូលដ្ឋានទិន្នន័យ",
   "aboutAppVersion": "កំណែនៃកម្មវិធី",
@@ -69,6 +72,7 @@
   "txRefLabel": "លេខយោង: {ref}"
   ,
   "settingsLowStockThreshold": "កម្រិតស្តុកទាប",
+  "settingsLowStockThresholdDescription": "ជូនដំណឹងនៅពេលស្តុកទាបជាង {threshold}",
   "adjustStockTitle": "កែតម្រូវស្តុក",
   "stockLabel": "ស្តុក",
   "decrease": "បន្ថយ",
@@ -82,6 +86,12 @@
   "notEnoughStockFor": "ស្តុកមិនគ្រប់សម្រាប់ {name}។ នៅសល់: {qty}"
   ,
   "settingsAllowOversell": "អនុញ្ញាតលក់លើស (ព្រមានតែប៉ុណ្ណោះ)",
+  "settingsReceiptSection": "ម៉ាកវិក្កយបត្រ",
+  "settingsReceiptSectionSubtitle": "ប្ដូររូបរាងហាងលើវិក្កយបត្រ។",
+  "settingsPaymentSection": "ការរួមបញ្ចូលការទូទាត់",
+  "settingsPaymentSectionSubtitle": "ចែករំលែក KHQR និងភ្ជាប់បុត Telegram។",
+  "settingsDangerZone": "តំបន់គ្រោះថ្នាក់",
+  "settingsDangerZoneSubtitle": "ចាកចេញពីឧបករណ៍នេះ។",
   "exceedsStock": "លើសស្តុក"
   ,
   "receipt": "វិក្កយបត្រ",

--- a/apps/lib/l10n/app_localizations.dart
+++ b/apps/lib/l10n/app_localizations.dart
@@ -170,6 +170,18 @@ abstract class AppLocalizations {
   /// **'Dark Mode'**
   String get settingsDarkMode;
 
+  /// No description provided for @settingsGeneralSection.
+  ///
+  /// In en, this message translates to:
+  /// **'Workspace'**
+  String get settingsGeneralSection;
+
+  /// No description provided for @settingsGeneralSectionSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Manage your profile and sync status.'**
+  String get settingsGeneralSectionSubtitle;
+
   /// No description provided for @settingsSyncNow.
   ///
   /// In en, this message translates to:
@@ -247,6 +259,36 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Batch size'**
   String get settingsBatchSize;
+
+  /// No description provided for @settingsBatchSizeHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Process {size} invoices per batch'**
+  String settingsBatchSizeHint(Object size);
+
+  /// No description provided for @settingsPreferencesSection.
+  ///
+  /// In en, this message translates to:
+  /// **'Preferences'**
+  String get settingsPreferencesSection;
+
+  /// No description provided for @settingsPreferencesSectionSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Personalize how the app looks and feels.'**
+  String get settingsPreferencesSectionSubtitle;
+
+  /// No description provided for @settingsSyncSection.
+  ///
+  /// In en, this message translates to:
+  /// **'Automation'**
+  String get settingsSyncSection;
+
+  /// No description provided for @settingsSyncSectionSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Fine tune batch sync and inventory safeguards.'**
+  String get settingsSyncSectionSubtitle;
 
   /// No description provided for @aboutTitle.
   ///
@@ -470,6 +512,12 @@ abstract class AppLocalizations {
   /// **'Low stock threshold'**
   String get settingsLowStockThreshold;
 
+  /// No description provided for @settingsLowStockThresholdDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Alert when stock falls below {threshold}'**
+  String settingsLowStockThresholdDescription(Object threshold);
+
   /// No description provided for @adjustStockTitle.
   ///
   /// In en, this message translates to:
@@ -529,6 +577,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Allow oversell (warn only)'**
   String get settingsAllowOversell;
+
+  /// No description provided for @settingsReceiptSection.
+  ///
+  /// In en, this message translates to:
+  /// **'Receipt branding'**
+  String get settingsReceiptSection;
+
+  /// No description provided for @settingsReceiptSectionSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Customize how your shop appears on printed receipts.'**
+  String get settingsReceiptSectionSubtitle;
+
+  /// No description provided for @settingsPaymentSection.
+  ///
+  /// In en, this message translates to:
+  /// **'Payment integrations'**
+  String get settingsPaymentSection;
+
+  /// No description provided for @settingsPaymentSectionSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Share KHQR codes and connect Telegram bots.'**
+  String get settingsPaymentSectionSubtitle;
+
+  /// No description provided for @settingsDangerZone.
+  ///
+  /// In en, this message translates to:
+  /// **'Danger zone'**
+  String get settingsDangerZone;
+
+  /// No description provided for @settingsDangerZoneSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Sign out of this device.'**
+  String get settingsDangerZoneSubtitle;
 
   /// No description provided for @exceedsStock.
   ///

--- a/apps/lib/l10n/app_localizations_en.dart
+++ b/apps/lib/l10n/app_localizations_en.dart
@@ -45,6 +45,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsDarkMode => 'Dark Mode';
 
   @override
+  String get settingsGeneralSection => 'Workspace';
+
+  @override
+  String get settingsGeneralSectionSubtitle => 'Manage your profile and sync status.';
+
+  @override
   String get settingsSyncNow => 'Sync now';
 
   @override
@@ -86,6 +92,23 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settingsBatchSize => 'Batch size';
+
+  @override
+  String settingsBatchSizeHint(Object size) {
+    return 'Process $size invoices per batch';
+  }
+
+  @override
+  String get settingsPreferencesSection => 'Preferences';
+
+  @override
+  String get settingsPreferencesSectionSubtitle => 'Personalize how the app looks and feels.';
+
+  @override
+  String get settingsSyncSection => 'Automation';
+
+  @override
+  String get settingsSyncSectionSubtitle => 'Fine tune batch sync and inventory safeguards.';
 
   @override
   String get aboutTitle => 'About';
@@ -205,6 +228,11 @@ class AppLocalizationsEn extends AppLocalizations {
   String get settingsLowStockThreshold => 'Low stock threshold';
 
   @override
+  String settingsLowStockThresholdDescription(Object threshold) {
+    return 'Alert when stock falls below $threshold';
+  }
+
+  @override
   String get adjustStockTitle => 'Adjust Stock';
 
   @override
@@ -235,6 +263,24 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get settingsAllowOversell => 'Allow oversell (warn only)';
+
+  @override
+  String get settingsReceiptSection => 'Receipt branding';
+
+  @override
+  String get settingsReceiptSectionSubtitle => 'Customize how your shop appears on printed receipts.';
+
+  @override
+  String get settingsPaymentSection => 'Payment integrations';
+
+  @override
+  String get settingsPaymentSectionSubtitle => 'Share KHQR codes and connect Telegram bots.';
+
+  @override
+  String get settingsDangerZone => 'Danger zone';
+
+  @override
+  String get settingsDangerZoneSubtitle => 'Sign out of this device.';
 
   @override
   String get exceedsStock => 'Exceeds stock';

--- a/apps/lib/l10n/app_localizations_km.dart
+++ b/apps/lib/l10n/app_localizations_km.dart
@@ -45,6 +45,12 @@ class AppLocalizationsKm extends AppLocalizations {
   String get settingsDarkMode => 'របៀបងងឹត';
 
   @override
+  String get settingsGeneralSection => 'កន្លែងធ្វើការ';
+
+  @override
+  String get settingsGeneralSectionSubtitle => 'គ្រប់គ្រងព័ត៌មានសម្គាល់ និងស្ថានភាពសមកាលកម្ម។';
+
+  @override
   String get settingsSyncNow => 'សមកាលកម្មឥឡូវនេះ';
 
   @override
@@ -86,6 +92,23 @@ class AppLocalizationsKm extends AppLocalizations {
 
   @override
   String get settingsBatchSize => 'ទំហំក្បាល';
+
+  @override
+  String settingsBatchSizeHint(Object size) {
+    return 'ដំណើរការ $size វិក័យប័ត្រក្នុងមួយក្បាល';
+  }
+
+  @override
+  String get settingsPreferencesSection => 'ចំណូលចិត្ត';
+
+  @override
+  String get settingsPreferencesSectionSubtitle => 'ប្ដូររបៀបដែលកម្មវិធីមើលទៅ និងមានអារម្មណ៍។';
+
+  @override
+  String get settingsSyncSection => 'សមកាលកម្មស្វ័យប្រវត្តិ';
+
+  @override
+  String get settingsSyncSectionSubtitle => 'លៃតម្រូវសមកាលកម្មជាក្បាល និងការពារស្តុក។';
 
   @override
   String get aboutTitle => 'អំពីកម្មវិធី';
@@ -205,6 +228,11 @@ class AppLocalizationsKm extends AppLocalizations {
   String get settingsLowStockThreshold => 'កម្រិតស្តុកទាប';
 
   @override
+  String settingsLowStockThresholdDescription(Object threshold) {
+    return 'ជូនដំណឹងនៅពេលស្តុកទាបជាង $threshold';
+  }
+
+  @override
   String get adjustStockTitle => 'កែតម្រូវស្តុក';
 
   @override
@@ -235,6 +263,24 @@ class AppLocalizationsKm extends AppLocalizations {
 
   @override
   String get settingsAllowOversell => 'អនុញ្ញាតលក់លើស (ព្រមានតែប៉ុណ្ណោះ)';
+
+  @override
+  String get settingsReceiptSection => 'ម៉ាកវិក្កយបត្រ';
+
+  @override
+  String get settingsReceiptSectionSubtitle => 'ប្ដូររូបរាងហាងលើវិក្កយបត្រ។';
+
+  @override
+  String get settingsPaymentSection => 'ការរួមបញ្ចូលការទូទាត់';
+
+  @override
+  String get settingsPaymentSectionSubtitle => 'ចែករំលែក KHQR និងភ្ជាប់បុត Telegram។';
+
+  @override
+  String get settingsDangerZone => 'តំបន់គ្រោះថ្នាក់';
+
+  @override
+  String get settingsDangerZoneSubtitle => 'ចាកចេញពីឧបករណ៍នេះ។';
 
   @override
   String get exceedsStock => 'លើសស្តុក';


### PR DESCRIPTION
## Summary
- redesign the settings screen around sectioned cards with icons, buttons, and inline sliders for a more polished experience
- style receipt, payment, and automation controls with reusable helpers and enhanced text fields
- add English and Khmer localization strings plus generated bindings for the new section titles and helper copy

## Testing
- No tests: Flutter SDK is unavailable in the container

------
https://chatgpt.com/codex/tasks/task_e_68cc8f1e89208332ba4eb3ec1a6ca83b